### PR TITLE
Update CI: migrate to Clang 19.1.0, fix typo, enable manual workflow trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,12 +57,12 @@ jobs:
       with:
         path: |
           C:/Program Files/LLVM
-        key: llvm-18.1.0
+        key: llvm-19.1.0
     
     - name: Install LLVM and Clang
       uses: KyleMayes/install-llvm-action@v2
       with:
-        version: "19.0.0"
+        version: "19.1.0"
         cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     # - name: Cache Eventlog manifest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Install LLVM and Clang
       uses: KyleMayes/install-llvm-action@v2
       with:
-        version: "18.1.0"
+        version: "19.0.0"
         cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     # - name: Cache Eventlog manifest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: "yama-build"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
         .nargs(0);
     program.add_argument("-u", "--uninstall")
         .default_value(false)
-        .help("Uninstall YAMA EventLog manifest. (only do uninstall operaiton)")
+        .help("Uninstall YAMA EventLog manifest. (only do uninstall operation)")
         .nargs(0);
     program.add_argument("-s", "--suppress").default_value(false).help("Suppress warning logs").nargs(0);
     program.add_argument("-q", "--quiet").default_value(false).help("Suppress all console outputs").nargs(0);


### PR DESCRIPTION
## Summary
This PR introduces three improvements to the build system and codebase:

1. **Upgrade LLVM/Clang**  
   Migrated from Clang 18.1.0 to Clang 19.1.0 to resolve CI build failures.  
2. **Typo fix**  
   Corrected a typo in the arguments menu for better clarity.  
3. **Workflow enhancements**  
   Added the `workflow_dispatch` event to the GitHub Actions configuration, enabling manual runs from the Actions UI.

## Rationale
- Clang 18.1.0 was causing build errors in the CI pipeline (see [failed build log](https://github.com/FreeDurok/YAMA/actions/runs/16517139618/job/46710311297)).
- Improves user-facing text consistency.
- Facilitates testing and debugging by allowing manual workflow execution.
- Fixes #13 

## Testing
- Verified successful builds with Clang 19.1.0 on Windows runners (see [successful build log](https://github.com/FreeDurok/YAMA/actions/runs/16517511246))..
- Manually triggered the workflow from the Actions UI to ensure correct behavior.

<img width="1462" height="695" alt="Yama" src="https://github.com/user-attachments/assets/ce822cd6-3e30-467e-9f18-a2f525ffcd86" />
